### PR TITLE
Fix a bug with usernames containing space - because /kick [playername…

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -111,7 +111,7 @@ class Player extends Human {
 	 * @returns {void}
 	 */
 	handleLogin(packet) {
-		this.username = TextFormat.clean(packet.username);
+		this.username = TextFormat.clean(packet.username).replace(" ", "_");
 		this.clientId = packet.clientId;
 
 		this.server.getLogger().info(`New connection from ${this.username} [/${this.connection.address.toString()}]`);


### PR DESCRIPTION
This pr fixes a bug with usernames containing space - because /kick [playername] [reason] or any other command that have player name as argument will not work for players with spaces in their usernames